### PR TITLE
Enable source maps for generated TypeScript contracts (resolves #37)

### DIFF
--- a/generators/chaincode/templates/typescript/tsconfig.json
+++ b/generators/chaincode/templates/typescript/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es2017",
         "moduleResolution": "node",
         "module": "commonjs",
-        "declaration": true
+        "declaration": true,
+        "sourceMap": true
     },
     "include": [
         "./src/**/*"

--- a/generators/contract/templates/typescript/tsconfig.json
+++ b/generators/contract/templates/typescript/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es2017",
         "moduleResolution": "node",
         "module": "commonjs",
-        "declaration": true
+        "declaration": true,
+        "sourceMap": true
     },
     "include": [
         "./src/**/*"

--- a/test/chaincode/typescript.js
+++ b/test/chaincode/typescript.js
@@ -133,6 +133,23 @@ describe('Chaincode (TypeScript)', () => {
                 lines: 100
             }
         });
+        const tsconfigJSON = require(path.join(dir, 'tsconfig.json'));
+        tsconfigJSON.should.deep.equal({
+            compilerOptions: {
+                outDir: 'dist',
+                target: 'es2017',
+                moduleResolution: 'node',
+                module: 'commonjs',
+                declaration: true,
+                sourceMap: true
+            },
+            include: [
+                './src/**/*'
+            ],
+            exclude: [
+                './src/**/*.spec.ts'
+            ]
+        });
     });
 
     it('should detect if no skip-install option is passed with typescript language', async () => {

--- a/test/contract/typescript.js
+++ b/test/contract/typescript.js
@@ -117,6 +117,23 @@ describe('Contract (TypeScript)', () => {
                 lines: 100
             }
         });
+        const tsconfigJSON = require(path.join(dir, 'tsconfig.json'));
+        tsconfigJSON.should.deep.equal({
+            compilerOptions: {
+                outDir: 'dist',
+                target: 'es2017',
+                moduleResolution: 'node',
+                module: 'commonjs',
+                declaration: true,
+                sourceMap: true
+            },
+            include: [
+                './src/**/*'
+            ],
+            exclude: [
+                './src/**/*.spec.ts'
+            ]
+        });
     });
 
 });


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>