### PR TITLE
Use SPDX license identifiers with correct license (resolves #41)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 
 root = true

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 
 coverage

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 module.exports = {

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 sudo: required
 services:
     - docker

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/generators/chaincode/index.js
+++ b/generators/chaincode/index.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -65,6 +52,7 @@ module.exports = class extends Generator {
         }];
         const answers = await this.prompt(questions);
         Object.assign(this.options, answers);
+        this.options.spdxAndLicense = `SPDX-License-Identifier: ${this.options.license}`;
     }
 
     async writing () {
@@ -87,6 +75,6 @@ module.exports = class extends Generator {
     }
 
     end(){
-        console.log('Finished generating contract');
+        console.log('Finished generating chaincode');
     }
 };

--- a/generators/chaincode/templates/go/.editorconfig
+++ b/generators/chaincode/templates/go/.editorconfig
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 root = true

--- a/generators/chaincode/templates/go/.gitignore-hidefromnpm
+++ b/generators/chaincode/templates/go/.gitignore-hidefromnpm
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 # Binaries for programs and plugins

--- a/generators/chaincode/templates/go/chaincode.go
+++ b/generators/chaincode/templates/go/chaincode.go
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 package main

--- a/generators/chaincode/templates/go/chaincode_test.go
+++ b/generators/chaincode/templates/go/chaincode_test.go
@@ -1,3 +1,7 @@
+/*
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
+ */
+
 package main
 
 import (

--- a/generators/chaincode/templates/go/main.go
+++ b/generators/chaincode/templates/go/main.go
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 package main

--- a/generators/chaincode/templates/java/.gitignore-hidefromnpm
+++ b/generators/chaincode/templates/java/.gitignore-hidefromnpm
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 .gradle

--- a/generators/chaincode/templates/java/build.gradle
+++ b/generators/chaincode/templates/java/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.3.0-SNAPSHOT'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.3.1-SNAPSHOT'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.+'
 }

--- a/generators/chaincode/templates/java/build.gradle
+++ b/generators/chaincode/templates/java/build.gradle
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 plugins {

--- a/generators/chaincode/templates/java/settings.gradle
+++ b/generators/chaincode/templates/java/settings.gradle
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 rootProject.name = '<%= name %>'

--- a/generators/chaincode/templates/java/src/main/java/org/example/Chaincode.java
+++ b/generators/chaincode/templates/java/src/main/java/org/example/Chaincode.java
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 package org.example;

--- a/generators/chaincode/templates/java/src/main/java/org/example/Start.java
+++ b/generators/chaincode/templates/java/src/main/java/org/example/Start.java
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 package org.example;

--- a/generators/chaincode/templates/java/src/test/java/org/example/ChaincodeTest.java
+++ b/generators/chaincode/templates/java/src/test/java/org/example/ChaincodeTest.java
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 package org.example;

--- a/generators/chaincode/templates/javascript/.editorconfig
+++ b/generators/chaincode/templates/javascript/.editorconfig
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 root = true

--- a/generators/chaincode/templates/javascript/.eslintignore
+++ b/generators/chaincode/templates/javascript/.eslintignore
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 coverage

--- a/generators/chaincode/templates/javascript/.eslintrc.js
+++ b/generators/chaincode/templates/javascript/.eslintrc.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 module.exports = {

--- a/generators/chaincode/templates/javascript/.gitignore-hidefromnpm
+++ b/generators/chaincode/templates/javascript/.gitignore-hidefromnpm
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 # Logs

--- a/generators/chaincode/templates/javascript/index.js
+++ b/generators/chaincode/templates/javascript/index.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 'use strict';

--- a/generators/chaincode/templates/javascript/lib/chaincode.js
+++ b/generators/chaincode/templates/javascript/lib/chaincode.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 'use strict';

--- a/generators/chaincode/templates/javascript/lib/start.js
+++ b/generators/chaincode/templates/javascript/lib/start.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 'use strict';

--- a/generators/chaincode/templates/javascript/test/chaincode.js
+++ b/generators/chaincode/templates/javascript/test/chaincode.js
@@ -1,3 +1,7 @@
+/*
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
+ */
+
 'use strict';
 
 const { ChaincodeStub } = require('fabric-shim');

--- a/generators/chaincode/templates/javascript/test/start.js
+++ b/generators/chaincode/templates/javascript/test/start.js
@@ -1,3 +1,7 @@
+/*
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
+ */
+
 'use strict';
 
 const { Shim } = require('fabric-shim');

--- a/generators/chaincode/templates/typescript/.editorconfig
+++ b/generators/chaincode/templates/typescript/.editorconfig
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 root = true

--- a/generators/chaincode/templates/typescript/.gitignore-hidefromnpm
+++ b/generators/chaincode/templates/typescript/.gitignore-hidefromnpm
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 # Logs

--- a/generators/chaincode/templates/typescript/src/chaincode.spec.ts
+++ b/generators/chaincode/templates/typescript/src/chaincode.spec.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { ChaincodeStub } from 'fabric-shim';

--- a/generators/chaincode/templates/typescript/src/chaincode.ts
+++ b/generators/chaincode/templates/typescript/src/chaincode.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { ChaincodeInterface, ChaincodeStub, Shim } from 'fabric-shim';

--- a/generators/chaincode/templates/typescript/src/index.ts
+++ b/generators/chaincode/templates/typescript/src/index.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 export { Chaincode } from './chaincode';

--- a/generators/chaincode/templates/typescript/src/start.spec.ts
+++ b/generators/chaincode/templates/typescript/src/start.spec.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { Shim } from 'fabric-shim';

--- a/generators/chaincode/templates/typescript/src/start.ts
+++ b/generators/chaincode/templates/typescript/src/start.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { Shim } from 'fabric-shim';

--- a/generators/contract/index.js
+++ b/generators/contract/index.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -63,6 +50,7 @@ module.exports = class extends Generator {
         }];
         const answers = await this.prompt(questions);
         Object.assign(this.options, answers);
+        this.options.spdxAndLicense = `SPDX-License-Identifier: ${this.options.license}`;
     }
 
     async writing () {

--- a/generators/contract/templates/javascript/.editorconfig
+++ b/generators/contract/templates/javascript/.editorconfig
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 root = true

--- a/generators/contract/templates/javascript/.eslintignore
+++ b/generators/contract/templates/javascript/.eslintignore
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 coverage

--- a/generators/contract/templates/javascript/.eslintrc.js
+++ b/generators/contract/templates/javascript/.eslintrc.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 module.exports = {

--- a/generators/contract/templates/javascript/.gitignore-hidefromnpm
+++ b/generators/contract/templates/javascript/.gitignore-hidefromnpm
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 # Logs

--- a/generators/contract/templates/javascript/index.js
+++ b/generators/contract/templates/javascript/index.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 'use strict';

--- a/generators/contract/templates/javascript/lib/my-contract.js
+++ b/generators/contract/templates/javascript/lib/my-contract.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 'use strict';

--- a/generators/contract/templates/javascript/test/my-contract.js
+++ b/generators/contract/templates/javascript/test/my-contract.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 'use strict';

--- a/generators/contract/templates/typescript/.editorconfig
+++ b/generators/contract/templates/typescript/.editorconfig
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 root = true

--- a/generators/contract/templates/typescript/.gitignore-hidefromnpm
+++ b/generators/contract/templates/typescript/.gitignore-hidefromnpm
@@ -1,15 +1,5 @@
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
 #
 
 # Logs

--- a/generators/contract/templates/typescript/src/index.ts
+++ b/generators/contract/templates/typescript/src/index.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { MyContract } from './my-contract';

--- a/generators/contract/templates/typescript/src/my-contract.spec.ts
+++ b/generators/contract/templates/typescript/src/my-contract.spec.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { Context } from 'fabric-contract-api';

--- a/generators/contract/templates/typescript/src/my-contract.ts
+++ b/generators/contract/templates/typescript/src/my-contract.ts
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>
  */
 
 import { Context, Contract } from 'fabric-contract-api';

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ex

--- a/test/chaincode/go.js
+++ b/test/chaincode/go.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -32,7 +19,7 @@ describe('Chaincode (Go)', () => {
                 version: '0.0.1',
                 description: 'My Go Chaincode',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             '.vscode/extensions.json',
@@ -42,6 +29,7 @@ describe('Chaincode (Go)', () => {
             'chaincode.go',
             'main.go'
         ]);
+        assert.fileContent('chaincode.go', /SPDX-License-Identifier: WTFPL/);
         assert.fileContent('chaincode.go', /func \(cc \*Chaincode\) Init\(stub shim\.ChaincodeStubInterface\) sc\.Response {/);
         assert.fileContent('chaincode.go', /func \(cc \*Chaincode\) Invoke\(stub shim\.ChaincodeStubInterface\) sc\.Response {/);
         assert.fileContent('main.go', /err := shim\.Start\(new\(Chaincode\)\)/);

--- a/test/chaincode/java.js
+++ b/test/chaincode/java.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -32,7 +19,7 @@ describe('Chaincode (Java)', () => {
                 version: '0.0.1',
                 description: 'My Java Chaincode',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             '.vscode/extensions.json',
@@ -47,6 +34,7 @@ describe('Chaincode (Java)', () => {
             'gradlew.bat',
             'settings.gradle'
         ]);
+        assert.fileContent('src/main/java/org/example/Chaincode.java', /SPDX-License-Identifier: WTFPL/);
         assert.fileContent('src/main/java/org/example/Chaincode.java', /public class Chaincode extends ChaincodeBase \{/);
         assert.fileContent('src/main/java/org/example/Chaincode.java', /public Response init\(ChaincodeStub stub\) \{/);
         assert.fileContent('src/main/java/org/example/Chaincode.java', /public Response invoke\(ChaincodeStub stub\) \{/);

--- a/test/chaincode/javascript.js
+++ b/test/chaincode/javascript.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -55,7 +42,7 @@ describe('Chaincode (JavaScript)', () => {
                 version: '0.0.1',
                 description: 'My JavaScript Chaincode',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             '.vscode/extensions.json',
@@ -70,6 +57,7 @@ describe('Chaincode (JavaScript)', () => {
             'index.js',
             'package.json'
         ]);
+        assert.fileContent('lib/chaincode.js', /SPDX-License-Identifier: WTFPL/);
         assert.fileContent('lib/chaincode.js', /class Chaincode extends ChaincodeInterface {/);
         assert.fileContent('lib/chaincode.js', /async Init\(stub\) {/);
         assert.fileContent('lib/chaincode.js', /async Invoke\(stub\) {/);
@@ -92,7 +80,7 @@ describe('Chaincode (JavaScript)', () => {
             },
             engineStrict: true,
             author: 'James Conga',
-            license: 'Apache-2.0',
+            license: 'WTFPL',
             dependencies: {
                 'fabric-shim': '1.4.0-snapshot.27'
             },

--- a/test/chaincode/typescript.js
+++ b/test/chaincode/typescript.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -53,7 +40,7 @@ describe('Chaincode (TypeScript)', () => {
                 version: '0.0.1',
                 description: 'My TypeScript Chaincode',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             '.vscode/extensions.json',
@@ -68,6 +55,7 @@ describe('Chaincode (TypeScript)', () => {
             'tsconfig.json',
             'tslint.json'
         ]);
+        assert.fileContent('src/chaincode.ts', /SPDX-License-Identifier: WTFPL/);
         assert.fileContent('src/chaincode.ts', /export class Chaincode implements ChaincodeInterface {/);
         assert.fileContent('src/chaincode.ts', /public async Init\(stub: ChaincodeStub\): Promise<any> {/);
         assert.fileContent('src/chaincode.ts', /public async Invoke\(stub: ChaincodeStub\): Promise<any> {/);
@@ -94,7 +82,7 @@ describe('Chaincode (TypeScript)', () => {
             },
             engineStrict: true,
             author: 'James Conga',
-            license: 'Apache-2.0',
+            license: 'WTFPL',
             dependencies: {
                 'fabric-shim': '1.4.0-snapshot.27'
             },

--- a/test/contract/javascript.js
+++ b/test/contract/javascript.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: WTFPL
  */
 
 'use strict';
@@ -48,7 +35,7 @@ describe('Contract (JavaScript)', () => {
         },
         engineStrict: true,
         author: 'James Conga',
-        license: 'Apache-2.0',
+        license: 'WTFPL',
         dependencies: {
             'fabric-contract-api': '1.4.0-snapshot.17',
             'fabric-shim': '1.4.0-snapshot.27'
@@ -92,7 +79,7 @@ describe('Contract (JavaScript)', () => {
                 version: '0.0.1',
                 description: 'My JavaScript Contract',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             'lib/my-contract.js',
@@ -104,6 +91,7 @@ describe('Contract (JavaScript)', () => {
             'index.js',
             'package.json'
         ]);
+        assert.fileContent('lib/my-contract.js', /SPDX-License-Identifier: WTFPL/);
         assert.fileContent('lib/my-contract.js', /class MyContract extends Contract {/);
         assert.fileContent('lib/my-contract.js', /async instantiate\(ctx\) {/);
         assert.fileContent('lib/my-contract.js', /async transaction1\(ctx, arg1\) {/);
@@ -123,7 +111,7 @@ describe('Contract (JavaScript)', () => {
                 version: '0.0.1',
                 description: 'My JavaScript Contract',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             '.vscode/extensions.json',
@@ -155,7 +143,7 @@ describe('Contract (JavaScript)', () => {
             version: '0.0.1',
             description: 'My JavaScript Contract',
             author: 'James Conga',
-            license: 'Apache-2.0',
+            license: 'WTFPL',
             dependencies: {
                 'fabric-contract-api': '1.4.0-snapshot.17',
                 'fabric-shim': '1.4.0-snapshot.27'
@@ -226,7 +214,7 @@ describe('Contract (JavaScript)', () => {
                 version: '0.0.1',
                 description: 'My JavaScript Contract',
                 author: 'James Conga',
-                license: 'Apache-2.0',
+                license: 'WTFPL',
                 destination: tmpdir
             });
 

--- a/test/contract/typescript.js
+++ b/test/contract/typescript.js
@@ -1,18 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';
@@ -38,7 +25,7 @@ describe('Contract (TypeScript)', () => {
                 version: '0.0.1',
                 description: 'My TypeScript Contract',
                 author: 'James Conga',
-                license: 'Apache-2.0'
+                license: 'WTFPL'
             });
         assert.file([
             '.vscode/extensions.json',
@@ -51,6 +38,7 @@ describe('Contract (TypeScript)', () => {
             'tsconfig.json',
             'tslint.json'
         ]);
+        assert.fileContent('src/my-contract.ts', /SPDX-License-Identifier: WTFPL/);
         assert.fileContent('src/my-contract.ts', /export class MyContract extends Contract {/);
         assert.fileContent('src/my-contract.ts', /public async instantiate\(ctx: Context\): Promise<any> {/);
         assert.fileContent('src/my-contract.ts', /public async transaction1\(ctx: Context, arg1: string\): Promise<any> {/);
@@ -77,7 +65,7 @@ describe('Contract (TypeScript)', () => {
             },
             engineStrict: true,
             author: 'James Conga',
-            license: 'Apache-2.0',
+            license: 'WTFPL',
             dependencies: {
                 'fabric-shim': '1.4.0-snapshot.27',
                 'fabric-contract-api': '1.4.0-snapshot.17'


### PR DESCRIPTION
The template fix is:
`# <%= spdxAndLicense // SPDX-License-Identifier: Apache-2.0 %>`

However, as well as that, all non-template license headers are being updated to:
`// SPDX-License-Identifier: Apache-2.0`

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>