### PR TITLE
Prune and remove package lock for shrinkwrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-fabric",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "generator-fabric",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "description": "Yeoman generator for Hyperledger Fabric",
     "main": "generators/app/index.js",
     "scripts": {
         "lint": "eslint .",
         "pretest": "npm run lint",
         "test": "nyc mocha --recursive",
-        "prepublishOnly": "npm shrinkwrap"
+        "prepublishOnly": "npm prune --production && rimraf package-lock.json && npm shrinkwrap"
     },
     "files": [
         "generators",
@@ -26,6 +26,7 @@
         "eslint": "^4.19.1",
         "mocha": "^5.2.0",
         "nyc": "^13.3.0",
+        "rimraf": "^2.6.3",
         "sinon": "^6.3.4",
         "sinon-chai": "^3.2.0",
         "yeoman-assert": "^3.1.1",


### PR DESCRIPTION
The `npm shrinkwrap` command stupidly includes devDependencies when there is a `package-lock.json` file, and doesn't include them when there isn't. IMO devDependencies should never be included in the shrinkwrapped version, and npm is a broken/confused mess.

If we run `npm prune` and delete the `package-lock.json` file, then we get what we want.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>