### PR TITLE
Update to version 1.4.2 Java Chaincode

### DIFF
--- a/generators/contract/templates/java/build.gradle
+++ b/generators/contract/templates/java/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.0-SNAPSHOT'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.4.2'
     compile group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,11 +1708,11 @@
             "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
         },
         "gradle-to-js": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/gradle-to-js/-/gradle-to-js-1.2.1.tgz",
-            "integrity": "sha512-HO13qBGUb7jCztEJYVu+s7iLMgN+Hlbi5UeNT+Kw2TT/Wvzx52whwg172/xDufz2kOaXJkp4PXVTRMbDbQG1Vw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/gradle-to-js/-/gradle-to-js-2.0.0.tgz",
+            "integrity": "sha512-eoYJiSoreHG0cS5aUmv7ISJhajuULlqdqG3QKVti6x1EFkBXE8rGH6ipGKWEesXpCkfNgzBrhzo5ztIH1JWZMw==",
             "requires": {
-                "lodash.merge": "4.6.1"
+                "lodash.merge": "4.6.2"
             }
         },
         "grouped-queue": {
@@ -2392,9 +2392,9 @@
             "dev": true
         },
         "lodash.merge": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "log-symbols": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "camelcase": "^5.3.1",
         "decamelize": "^3.2.0",
         "find-free-port": "^2.0.0",
-        "gradle-to-js": "^1.2.1",
+        "gradle-to-js": "^2.0.0",
         "yeoman-generator": "^4.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Now the 1.4.2 release of Java Chaincode is available use that one, rather than a snapshot

Signed-off-by: Matthew B. White <whitemat@uk.ibm.com>