### PR TITLE
Remove nexus repository and bump shim version

### DIFF
--- a/generators/chaincode/templates/java/build.gradle
+++ b/generators/chaincode/templates/java/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.4'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.5'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.+'
 }
@@ -19,9 +19,6 @@ repositories {
     mavenCentral()
     maven {
         url 'https://jitpack.io'
-    }
-    maven {
-        url "https://nexus.hyperledger.org/content/repositories/snapshots/"
     }
 }
 

--- a/generators/chaincode/templates/kotlin/build.gradle
+++ b/generators/chaincode/templates/kotlin/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.4'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.5'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0-RC2'
@@ -21,9 +21,6 @@ repositories {
     jcenter()
     maven {
         url 'https://jitpack.io'
-    }
-    maven {
-        url "https://nexus.hyperledger.org/content/repositories/snapshots/"
     }
 }
 

--- a/generators/contract/templates/public/java/build.gradle
+++ b/generators/contract/templates/public/java/build.gradle
@@ -16,13 +16,10 @@ repositories {
     maven {
         url 'https://jitpack.io'
     }
-    maven {
-        url "https://nexus.hyperledger.org/content/repositories/snapshots/"
-    }
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.4.4'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.4.5'
     compile group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/generators/contract/templates/public/kotlin/build.gradle
+++ b/generators/contract/templates/public/kotlin/build.gradle
@@ -17,7 +17,7 @@ version '0.0.1'
 sourceCompatibility = 1.8
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.4'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.5'
     implementation 'org.json:json:20180813'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
@@ -30,9 +30,6 @@ repositories {
     jcenter()
     maven {
         url 'https://jitpack.io'
-    }
-    maven {
-        url "https://nexus.hyperledger.org/content/repositories/snapshots/"
     }
 }
 


### PR DESCRIPTION
Nexus is no more.
Removing it as a repository, as bumping shim version to 1.4.5.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>