### PR TITLE
Teardown script updated

### DIFF
--- a/generators/chaincode/templates/javascript/package.json
+++ b/generators/chaincode/templates/javascript/package.json
@@ -17,7 +17,8 @@
   "author": "<%= author %>",
   "license": "<%= license %>",
   "dependencies": {
-    "fabric-shim": "^1.4.5"
+    "fabric-shim": "^1.4.5",
+    "jsrsasign": "^8.0.17"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/generators/chaincode/templates/typescript/package.json
+++ b/generators/chaincode/templates/typescript/package.json
@@ -21,7 +21,8 @@
   "author": "<%= author %>",
   "license": "<%= license %>",
   "dependencies": {
-    "fabric-shim": "^1.4.5"
+    "fabric-shim": "^1.4.5",
+    "jsrsasign": "^8.0.17"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/generators/contract/templates/default/javascript/package.json
+++ b/generators/contract/templates/default/javascript/package.json
@@ -18,7 +18,8 @@
   "license": "<%= license %>",
   "dependencies": {
     "fabric-contract-api": "^1.4.5",
-    "fabric-shim": "^1.4.5"
+    "fabric-shim": "^1.4.5",
+    "jsrsasign": "^8.0.17"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/generators/contract/templates/default/typescript/package.json
+++ b/generators/contract/templates/default/typescript/package.json
@@ -22,7 +22,8 @@
   "license": "<%= license %>",
   "dependencies": {
     "fabric-contract-api": "^1.4.5",
-    "fabric-shim": "^1.4.5"
+    "fabric-shim": "^1.4.5",
+    "jsrsasign": "^8.0.17"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/generators/contract/templates/private/javascript/package.json
+++ b/generators/contract/templates/private/javascript/package.json
@@ -18,7 +18,8 @@
   "license": "<%= license %>",
   "dependencies": {
     "fabric-contract-api": "^1.4.5",
-    "fabric-shim": "^1.4.5"
+    "fabric-shim": "^1.4.5",
+    "jsrsasign": "^8.0.17"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/generators/contract/templates/private/typescript/package.json
+++ b/generators/contract/templates/private/typescript/package.json
@@ -22,7 +22,8 @@
   "license": "<%= license %>",
   "dependencies": {
     "fabric-contract-api": "^1.4.5",
-    "fabric-shim": "^1.4.5"
+    "fabric-shim": "^1.4.5",
+    "jsrsasign": "^8.0.17"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/generators/network/templates/teardown.cmd
+++ b/generators/network/templates/teardown.cmd
@@ -17,6 +17,12 @@ for /f "usebackq tokens=*" %%v in (`docker volume ls -f label^=fabric-environmen
         exit /b !errorlevel!
     )
 )
+for /f "usebackq tokens=*" %%b in (`docker images "<%= name %>-*" -a -q`) do (
+    docker volume rm -f %%b
+    if !errorlevel! neq 0 (
+        exit /b !errorlevel!
+    )
+)
 if exist wallets (
     pushd wallets
     rmdir /q/s .

--- a/generators/network/templates/teardown.sh
+++ b/generators/network/templates/teardown.sh
@@ -12,6 +12,9 @@ done
 for VOLUME in $(docker volume ls -f label=fabric-environment-name="<%= name %>" -q); do
     docker volume rm -f ${VOLUME}
 done
+for IMAGE in $(docker images "<%= name %>-*" -a -q); do
+    docker image rm -f ${IMAGE}
+done
 docker run --rm -v "$PWD":/network ibmblockchain/vscode-prereqs:0.0.16 chown -R $(id -u):$(id -g) /network
 if [ -d wallets ]; then
     for WALLET in $(ls wallets); do

--- a/package-lock.json
+++ b/package-lock.json
@@ -1591,9 +1591,9 @@
                     },
                     "dependencies": {
                         "lodash": {
-                            "version": "4.17.15",
-                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                            "version": "4.17.20",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
                             "dev": true
                         }
                     }
@@ -2044,6 +2044,15 @@
                 "flat-cache": "^2.0.1"
             }
         },
+        "filelist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
+            "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.4"
+            }
+        },
         "fill-range": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2469,16 +2478,14 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.1.0.tgz",
             "integrity": "sha512-rZOFKfCqLhsu5VqjBjEWiwrYqJR07KxIkH4mLZlNlGDfntbb4FbMyGFP14TlvRPrU9S3Hnn/sgxbC5ZeN0no3Q==",
-            "optional": true,
             "requires": {
                 "lodash": "^4.17.15"
             },
             "dependencies": {
                 "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "optional": true
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
                 }
             }
         },
@@ -2737,9 +2744,9 @@
                     "optional": true
                 },
                 "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
                     "optional": true
                 },
                 "run-async": {
@@ -3169,6 +3176,26 @@
                 "textextensions": "^2.5.0"
             }
         },
+        "jake": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+            "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+            "dev": true,
+            "requires": {
+                "async": "0.9.x",
+                "chalk": "^2.4.2",
+                "filelist": "^1.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                }
+            }
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3246,6 +3273,16 @@
                 "verror": "1.10.0"
             }
         },
+        "jsrsasign": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-9.1.2.tgz",
+            "integrity": "sha512-MHCjxvdaCmw1eCaw+8l84Qpmi3vtuO9yjxMSMXR1xCucKxyqRmxtlJaiM0V62vwqM1QO2z8cT4KCikMll84Zew=="
+        },
+        "jsrsasign-util": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/jsrsasign-util/-/jsrsasign-util-1.0.0.tgz",
+            "integrity": "sha1-zpTsGqEZw5E0yWeueE+Djy4pA+Y="
+        },
         "just-extend": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
@@ -3290,9 +3327,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.14",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "lodash.flattendeep": {
             "version": "4.4.0",
@@ -3530,18 +3567,11 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
+                "minimist": "^1.2.5"
             }
         },
         "mocha": {
@@ -5734,9 +5764,9 @@
                     "dev": true
                 },
                 "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
                     "dev": true
                 },
                 "string-width": {
@@ -6048,6 +6078,15 @@
                         "path-type": "^3.0.0"
                     }
                 },
+                "ejs": {
+                    "version": "3.1.5",
+                    "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.5.tgz",
+                    "integrity": "sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==",
+                    "dev": true,
+                    "requires": {
+                        "jake": "^10.6.1"
+                    }
+                },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -6076,15 +6115,6 @@
                         "ignore": "^3.3.5",
                         "pify": "^3.0.0",
                         "slash": "^1.0.0"
-                    }
-                },
-                "grouped-queue": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.1.0.tgz",
-                    "integrity": "sha512-rZOFKfCqLhsu5VqjBjEWiwrYqJR07KxIkH4mLZlNlGDfntbb4FbMyGFP14TlvRPrU9S3Hnn/sgxbC5ZeN0no3Q==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "^4.17.15"
                     }
                 },
                 "has-flag": {
@@ -6127,9 +6157,9 @@
                     "dev": true
                 },
                 "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
                     "dev": true
                 },
                 "mimic-fn": {
@@ -6229,9 +6259,9 @@
                     "dev": true
                 },
                 "yeoman-environment": {
-                    "version": "2.10.0",
-                    "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.10.0.tgz",
-                    "integrity": "sha512-dn754zZm1kTWS94V5riNLNjs9Wn6Zjl+9jgbQ37EmHEhcRR30fY1sgBnhYZyTpa+zK7ipFI6dMH9Sg0SAMW3hw==",
+                    "version": "2.10.3",
+                    "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.10.3.tgz",
+                    "integrity": "sha512-pLIhhU9z/G+kjOXmJ2bPFm3nejfbH+f1fjYRSOteEXDBrv1EoJE/e+kuHixSXfCYfTkxjYsvRaDX+1QykLCnpQ==",
                     "dev": true,
                     "requires": {
                         "chalk": "^2.4.1",
@@ -6323,9 +6353,9 @@
                     }
                 },
                 "yeoman-generator": {
-                    "version": "4.10.0",
-                    "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.10.0.tgz",
-                    "integrity": "sha512-NuY9bt7r6kvjvWjAVcujZwHux5xXy4Vdmz3uabyjioh679ry97+dl+MgtlAkgdSQ7kGI0Iz1GC92tZ33XdxaDw==",
+                    "version": "4.11.0",
+                    "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.11.0.tgz",
+                    "integrity": "sha512-++t6t2Z6HjL5F1/UM7+uNvGknKmQdF8tstJx8WKzsUSEpB+19kLVtapSfQIh9uWqm0L59fLWDzUui//WXoynPw==",
                     "dev": true,
                     "requires": {
                         "async": "^2.6.2",
@@ -6343,7 +6373,7 @@
                         "istextorbinary": "^2.5.1",
                         "lodash": "^4.17.11",
                         "make-dir": "^3.0.0",
-                        "mem-fs-editor": "^6.0.0",
+                        "mem-fs-editor": "^7.0.1",
                         "minimist": "^1.2.5",
                         "pretty-bytes": "^5.2.0",
                         "read-chunk": "^3.2.0",
@@ -6407,10 +6437,77 @@
                             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
                             "dev": true
                         },
+                        "dir-glob": {
+                            "version": "2.2.2",
+                            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                            "dev": true,
+                            "requires": {
+                                "path-type": "^3.0.0"
+                            }
+                        },
+                        "globby": {
+                            "version": "9.2.0",
+                            "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+                            "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+                            "dev": true,
+                            "requires": {
+                                "@types/glob": "^7.1.1",
+                                "array-union": "^1.0.2",
+                                "dir-glob": "^2.2.2",
+                                "fast-glob": "^2.2.6",
+                                "glob": "^7.1.3",
+                                "ignore": "^4.0.3",
+                                "pify": "^4.0.1",
+                                "slash": "^2.0.0"
+                            }
+                        },
                         "has-flag": {
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                            "dev": true
+                        },
+                        "ignore": {
+                            "version": "4.0.6",
+                            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                            "dev": true
+                        },
+                        "mem-fs-editor": {
+                            "version": "7.0.1",
+                            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-7.0.1.tgz",
+                            "integrity": "sha512-eD8r4/d2ayp9HHIgBPHB6Ds0ggA8F9cf9HxcNtbqrwqJXfIDrOSMG5K4fV3+Ib3B+HIdrWqkeDDDvrO7i9EbvQ==",
+                            "dev": true,
+                            "requires": {
+                                "commondir": "^1.0.1",
+                                "deep-extend": "^0.6.0",
+                                "ejs": "^3.0.1",
+                                "glob": "^7.1.4",
+                                "globby": "^9.2.0",
+                                "isbinaryfile": "^4.0.0",
+                                "mkdirp": "^1.0.0",
+                                "multimatch": "^4.0.0",
+                                "rimraf": "^3.0.0",
+                                "through2": "^3.0.1",
+                                "vinyl": "^2.2.0"
+                            },
+                            "dependencies": {
+                                "rimraf": {
+                                    "version": "3.0.2",
+                                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                                    "dev": true,
+                                    "requires": {
+                                        "glob": "^7.1.3"
+                                    }
+                                }
+                            }
+                        },
+                        "pify": {
+                            "version": "4.0.1",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                             "dev": true
                         },
                         "rimraf": {
@@ -6421,6 +6518,12 @@
                             "requires": {
                                 "glob": "^7.1.3"
                             }
+                        },
+                        "slash": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                            "dev": true
                         },
                         "supports-color": {
                             "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "lint": "eslint .",
         "pretest": "npm run lint",
-        "test": "nyc mocha --recursive",
+        "test": "nyc mocha -t 3000 --recursive",
         "prepublishOnly": "rimraf package-lock.json && npm prune --production && npm shrinkwrap"
     },
     "files": [
@@ -23,6 +23,8 @@
         "decamelize": "^4.0.0",
         "find-free-port": "^2.0.0",
         "gradle-to-js": "^2.0.0",
+        "jsrsasign": "^9.1.2",
+        "jsrsasign-util": "^1.0.0",
         "yeoman-generator": "^4.7.2"
     },
     "devDependencies": {
@@ -31,7 +33,7 @@
         "chai-subset": "^1.6.0",
         "eslint": "^6.8.0",
         "js-yaml": "^3.13.1",
-        "mocha": "^7.1.1",
+        "mocha": "7.1.2",
         "nyc": "^15.0.0",
         "rimraf": "^3.0.2",
         "sinon": "^9.0.1",

--- a/scripts/network/teardown.sh
+++ b/scripts/network/teardown.sh
@@ -12,6 +12,9 @@ done
 for VOLUME in $(docker volume ls -f label=fabric-environment-name="yofn" -q); do
     docker volume rm -f ${VOLUME}
 done
+for IMAGE in $(docker images "yofn-*" -a -q); do
+    docker image rm -f ${IMAGE}
+done
 docker run --rm -v "$PWD":/network ibmblockchain/vscode-prereqs:0.0.10 chown -R $(id -u):$(id -g) /network
 if [ -d wallets ]; then
     for WALLET in $(ls wallets); do

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -37,6 +37,7 @@ fi
 if [ "$1" == "private_contract_tests" ]
 then
     pushd tmp
+    curl -sSL http://bit.ly/2ysbOFE | bash -s 1.4.4
     mkdir yofn
     pushd yofn
     cp ../../scripts/network/*.* ./

--- a/test/network.js
+++ b/test/network.js
@@ -58,8 +58,10 @@ describe('Network', () => {
         assert.fileContent('stop.sh', /docker ps -f label=fabric-environment-name="local_fabric" -q/);
         assert.fileContent('teardown.cmd', /docker ps -f label\^=fabric-environment-name\^="local_fabric" -q -a/);
         assert.fileContent('teardown.cmd', /docker volume ls -f label\^=fabric-environment-name\^="local_fabric" -q/);
+        assert.fileContent('teardown.cmd', /docker images "local_fabric-\*" -a -q/);
         assert.fileContent('teardown.sh', /docker ps -f label=fabric-environment-name="local_fabric" -q -a/);
         assert.fileContent('teardown.sh', /docker volume ls -f label=fabric-environment-name="local_fabric" -q/);
+        assert.fileContent('teardown.sh', /docker images "local_fabric-\*" -a -q/);
     }
 
     it('should generate a one organization network using prompts into a test directory', async () => {


### PR DESCRIPTION
Signed-off-by: Kestutis Gudynas <44440041+kemi04@users.noreply.github.com>
Closes #2238

@lquintai noticed that smart contract Docker image names are not decided at the extension nor at the chaincode sdk level, but at the fabric level.
Common observations about how environment names are added to image names: environment names are turned into strings consisting only of lower-case alphanumeric characters, for example: 
Environment name: `STRANGE-name_! 1 2local`
Chaincode image name: `strangename12local-org1peer1-go0209extraextrapath-0.0.1-cb8fdbd3fe85ae4e5291b7adfec4e326ee78ea8e333f666a7dfbbbc7a6f9ff02`
It was advised to use the _best guess_ approach: environment name is turned into a string conforming the observations above and, if there exists an image with such a name - it is deleted. Otherwise, the image remains on the user machine.