### PR TITLE
[v2] change endorsement policy in collections file for v1 private contracts

### DIFF
--- a/generators/contract/templates/v1/private/java/collections.json
+++ b/generators/contract/templates/v1/private/java/collections.json
@@ -1,24 +1,8 @@
 [
     {
          "name": "CollectionOne",
-         "policy": {
-              "identities": [
-                   {
-                        "role": {
-                             "name": "member",
-                             "mspId": "<%= mspId %>"
-                        }
-                   }
-              ],
-              "policy": {
-                   "1-of": [
-                        {
-                             "signed-by": 0
-                        }
-                   ]
-              }
-         },
-         "requiredPeerCount": 1,
+         "policy": "OR('<%= mspId %>.member')",
+         "requiredPeerCount": 0,
          "maxPeerCount": 1,
          "blockToLive": 0,
          "memberOnlyRead": true

--- a/generators/contract/templates/v1/private/javascript/collections.json
+++ b/generators/contract/templates/v1/private/javascript/collections.json
@@ -1,24 +1,8 @@
 [
     {
          "name": "CollectionOne",
-         "policy": {
-              "identities": [
-                   {
-                        "role": {
-                             "name": "member",
-                             "mspId": "<%= mspId %>"
-                        }
-                   }
-              ],
-              "policy": {
-                   "1-of": [
-                        {
-                             "signed-by": 0
-                        }
-                   ]
-              }
-         },
-         "requiredPeerCount": 1,
+         "policy": "OR('<%= mspId %>.member')",
+         "requiredPeerCount": 0,
          "maxPeerCount": 1,
          "blockToLive": 0,
          "memberOnlyRead": true

--- a/generators/contract/templates/v1/private/typescript/collections.json
+++ b/generators/contract/templates/v1/private/typescript/collections.json
@@ -1,24 +1,8 @@
 [
     {
          "name": "CollectionOne",
-         "policy": {
-              "identities": [
-                   {
-                        "role": {
-                             "name": "member",
-                             "mspId": "<%= mspId %>"
-                        }
-                   }
-              ],
-              "policy": {
-                   "1-of": [
-                        {
-                             "signed-by": 0
-                        }
-                   ]
-              }
-         },
-         "requiredPeerCount": 1,
+         "policy": "OR('<%= mspId %>.member')",
+         "requiredPeerCount": 0,
          "maxPeerCount": 1,
          "blockToLive": 0,
          "memberOnlyRead": true


### PR DESCRIPTION
Change endorsement policy to a one liner like the v2 equivalent. Needed as we will no longer use fabric-client from v1 node SDK in the merged IBM Blockchain Platform extension.

Also updated `requiredPeerCount` from 1 to 0. This value represents the number of other peers that the peer executing the smart contract should send the private data to within the same organisation. Our organisations only have one peer each. Unsure how having it set to 1 ever worked.



Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>