### PR TITLE
Fix tests

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -24,6 +24,13 @@ fi
 if [ "$1" != "network_test" ]; then
     pushd tmp
     curl -sSL http://bit.ly/2ysbOFE | bash -s 2.2.0
+    # fabric-ca:1.4.7 includes an expired certificate which breaks the tests
+    # unfortunately generate.sh uses vscode-prereqs:fabric-v2.2 which has been archived
+    # see https://github.com/IBM-Blockchain-Archive/ansible-role-blockchain-platform-manager
+    # ideally the tests would create networks using something which hasn't been archived but
+    # tagging a working version of fabric-ca with 1.4.7 fixes the tests
+    docker pull hyperledger/fabric-ca:1.5
+    docker tag hyperledger/fabric-ca:1.5 hyperledger/fabric-ca:1.4.7
     mkdir yofn
     pushd yofn
     cp ../../scripts/network/*.* ./

--- a/test/contract/default/javascript.js
+++ b/test/contract/default/javascript.js
@@ -97,8 +97,8 @@ describe('Contract (JavaScript)', () => {
         });
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
     });
@@ -173,8 +173,8 @@ describe('Contract (JavaScript)', () => {
         });
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
     });

--- a/test/contract/default/typescript.js
+++ b/test/contract/default/typescript.js
@@ -95,8 +95,8 @@ describe('Contract (TypeScript)', () => {
         });
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
         const tsconfigJSON = require(path.join(dir, 'tsconfig.json'));
@@ -196,8 +196,8 @@ describe('Contract (TypeScript)', () => {
         });
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
         const tsconfigJSON = require(path.join(dir, 'tsconfig.json'));

--- a/test/contract/private/javascript.js
+++ b/test/contract/private/javascript.js
@@ -57,8 +57,8 @@ describe('Contract (JavaScript, private)', () => {
         const packageJSON = require(path.join(dir, 'package.json'));
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
     });
@@ -95,8 +95,8 @@ describe('Contract (JavaScript, private)', () => {
         const packageJSON = require(path.join(dir, 'package.json'));
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
     });

--- a/test/contract/private/typescript.js
+++ b/test/contract/private/typescript.js
@@ -56,8 +56,8 @@ describe('Contract (TypeScript, private)', () => {
         const packageJSON = require(path.join(dir, 'package.json'));
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
     });
@@ -96,8 +96,8 @@ describe('Contract (TypeScript, private)', () => {
         const packageJSON = require(path.join(dir, 'package.json'));
         packageJSON.should.containSubset({
             dependencies: {
-                'fabric-contract-api': '^2.2.0',
-                'fabric-shim': '^2.2.0'
+                'fabric-contract-api': '^2.4.1',
+                'fabric-shim': '^2.4.1'
             }
         });
     });


### PR DESCRIPTION
The fabric dependencies in generated contracts were updated by the automated Audit GitHub action, but not the tests so updating the tests to match

Also includes a hack to work around the broken/archived vscode-prereqs:fabric-v2.2 tool

Signed-off-by: James Taylor <jamest@uk.ibm.com>